### PR TITLE
feat: Implement 404 Page Not Found

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,7 @@ import Dashboard from "./pages/Dashboard";
 import { AuthProvider } from "./context/AuthContext";
 import PrivateRoute from "./components/PrivateRoute";
 import { appVersion } from "./version";
+import NotFound from "./pages/NotFound";
 
 
 function App() {
@@ -30,6 +31,8 @@ function App() {
                   </PrivateRoute>
                 } 
               />
+              <Route path="*" element={<NotFound />} />
+
             </Routes>
           </main>
 

--- a/frontend/src/pages/NotFound.js
+++ b/frontend/src/pages/NotFound.js
@@ -1,0 +1,12 @@
+export default function NotFound() {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen">
+        <h1 className="text-5xl font-bold text-green-500 mb-4">404</h1>
+        <p className="text-lg text-gray-600">Oeps! Pagina niet gevonden.</p>
+        <a href="/" className="mt-6 text-green-600 hover:underline">
+          Ga terug naar Home
+        </a>
+      </div>
+    );
+  }
+  


### PR DESCRIPTION
Toegevoegd: 404 pagina (`NotFound.js`) voor alle niet-bestaande routes.
Route `path="*"` afgevangen in `App.js`.
Consistente styling met Fluens branding.
