### PR TITLE
Remove stray prompt from NotFound page

### DIFF
--- a/frontend/src/pages/NotFound.js
+++ b/frontend/src/pages/NotFound.js
@@ -9,4 +9,3 @@ export default function NotFound() {
       </div>
     );
   }
-  


### PR DESCRIPTION
## Summary
- clean up `NotFound` page by removing a stray shell prompt line

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*